### PR TITLE
Fix refresh token bug

### DIFF
--- a/middleware/auth.ts
+++ b/middleware/auth.ts
@@ -1,19 +1,26 @@
 import { ROUTE } from '@/constants/route';
 
+type RefreshResponse = {
+  statusCode: number;
+  statusMessage?: string;
+  access_token: string;
+};
+
 export default defineNuxtRouteMiddleware(async (to, from) => {
+  if (!import.meta.client) return;
+
   const auth = useAuthState();
   if (auth.value.isAuthenticated) return;
 
   const { fetchWithAuth } = useFetchWithAuth();
 
   try {
-    const response = await fetchWithAuth<Response>('/api/auth/refresh', { method: 'POST' });
-    const data = await response.json();
+    const response = await fetchWithAuth<RefreshResponse>('/api/auth/refresh', { method: 'POST' });
 
-    if (!response.ok) throw new Error('Refresh token invalid');
+    if (response.statusCode !== 200) throw new Error('Refresh token invalid');
 
     auth.value.isAuthenticated = true;
-    auth.value.accessToken = data.access_token;
+    auth.value.accessToken = response.access_token;
   } catch (error) {
     resetAuth();
     return navigateTo(ROUTE.LOGIN);

--- a/server/api/auth/login.ts
+++ b/server/api/auth/login.ts
@@ -31,7 +31,7 @@ export default defineEventHandler(async event => {
     serialize('refresh_token', refreshToken, {
       httpOnly: true,
       secure: process.env.NODE_ENV === 'production',
-      sameSite: 'strict',
+      sameSite: 'lax',
       path: '/',
       maxAge: 60 * 60 * 24 * 7,
     })


### PR DESCRIPTION
Fix refresh token bug.

- The middleware runs server side too, so refresh api could't read browser cookie,